### PR TITLE
Repointed EadId fields from EadId to id_0 .. id_N

### DIFF
--- a/Aeon-ArchivesSpace-Addon/Aeon-ArchivesSpace.lua
+++ b/Aeon-ArchivesSpace-Addon/Aeon-ArchivesSpace.lua
@@ -375,7 +375,7 @@ function PopulateDataGrid()
             local availableData = {};
             availableData["ArchivalObjectTitle"] = ExtractProperty(archivalObject, "title");
             availableData["ResourceTitle"] = ExtractProperty(collection, "title");
-            availableData["EadId"] = ExtractProperty(collection,"ead_id");
+            availableData["EadId"] = ExtractResourceIdentifier(collection);
             availableData["Creators"] = ExtractCreators(sessionId, collection);
 
             catalogSearchForm.Grid.GridControl:BeginUpdate();
@@ -456,13 +456,35 @@ function ImportCitation_Clicked()
     SwitchToDetailsTab();
 end
 
+function ExtractResourceIdentifier(collection)
+    local identifier = ''
+
+    local id_components = {
+        ExtractProperty(collection, 'id_0'),
+        ExtractProperty(collection, 'id_1'),
+        ExtractProperty(collection, 'id_2'),
+        ExtractProperty(collection, 'id_3'),
+    };
+
+    for _, value in ipairs(id_components) do
+        if value and value ~= '' then
+            identifier = identifier .. value .. '-';
+        end
+    end
+
+    -- Strips ending whitespace and dashes
+    identifier = identifier:match('^(.*[^%s-])[-%s]*$')
+
+    return identifier
+end
+
 function ExtractResourceCitation(sessionId, json)
     local availableData = {};
     availableData["Title"] = ExtractProperty(json, "title");
     availableData["Creators"] = ExtractCreators(sessionId, json);
     availableData["CreatedBy"] = ExtractProperty(json, "created_by");
     availableData["FindingAidTitle"] = ExtractProperty(json, "finding_aid_title");
-    availableData["EadId"] = ExtractProperty(json, "ead_id");
+    availableData["EadId"] = ExtractResourceIdentifier(json);
     local dates = ExtractProperty(json, "dates");
     availableData["DateExpression"] = ExtractProperty(dates[1], "expression");
 
@@ -475,6 +497,7 @@ function ExtractAccessionCitation(sessionId, json)
     availableData["DisplayString"] = ExtractProperty(json, "display_string");
     availableData["AccessionDate"] = ExtractProperty(json, "accession_date");
     availableData["CreatedBy"] = ExtractProperty(json, "created_by");
+    availableData["EadId"] = ExtractResourceIdentifier(json);
     local dates = ExtractProperty(json, "dates");
     availableData["DateExpression"] = ExtractProperty(dates[1], "expression");
 

--- a/Aeon-ArchivesSpace-Addon/Config.xml
+++ b/Aeon-ArchivesSpace-Addon/Config.xml
@@ -2,7 +2,7 @@
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>ArchivesSpace Interface</Name>
   <Author>Atlas Systems, Inc.</Author>
-  <Version>1.3.0</Version>
+  <Version>1.4.0</Version>
   <Active>True</Active>
   <Type>Addon</Type>
   <Description>This addon performs searches in ArchivesSpace using the staff interface. This addon supports ArchivesSpace versions v2.0.0 and later.</Description>

--- a/Aeon-ArchivesSpace-Addon/DataMapping.lua
+++ b/Aeon-ArchivesSpace-Addon/DataMapping.lua
@@ -81,7 +81,10 @@ HostAppInfo.CitationDataImport["Resource"] = {
   },
   {
     AeonField = "ItemDate", AspaceData = "DateExpression", FieldLength = 50
-  }
+  },
+  {
+    AeonField = "CallNumber", AspaceData = "EadId", FieldLength = 255
+  },
 }
 
 HostAppInfo.CitationDataImport["Accession"] = {
@@ -93,7 +96,10 @@ HostAppInfo.CitationDataImport["Accession"] = {
   },
   {
     AeonField = "ItemDate", AspaceData = "DateExpression", FieldLength = 50
-  }
+  },
+  {
+    AeonField = "CallNumber", AspaceData = "EadId", FieldLength = 255
+  },
 }
 
 HostAppInfo.CitationDataImport["DigitalObject"] = {

--- a/Readme.md
+++ b/Readme.md
@@ -72,13 +72,13 @@ InstanceDataImport establishes the mapping between an Aeon field and data from A
 
 #### Available ArchivesSpace Data- *Archival Object*
 
-| Data Mapping Name       | Description                                                                               | ArchivesSpace API Property                    |
-|-------------------------|-------------------------------------------------------------------------------------------|-----------------------------------------------|
-| ArchivalObjectTitle     | The title of the archival object                                                          | archival_objects > title                      |
-| ResourceTitle           | The title of the resource that the archival object belongs to                             | resources > title                             |
-| EadId                   | The resource's EAD ID                                                                     | resources > ead_id                            |
+| Data Mapping Name       | Description                                                                              | ArchivesSpace API Property                    |
+| ----------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------- |
+| ArchivalObjectTitle     | The title of the archival object                                                         | archival_objects > title                      |
+| ResourceTitle           | The title of the resource that the archival object belongs to                            | resources > title                             |
+| EadId                   | The resource's composite identifier                                                      | resources > (id_0, id_1, id_2, id_3)          |
 | Creators                | The primary names of the creators associated with the archival object delimited by a `;` | agents > people > display_name > primary_name |
-| ArchivalObjectContainer | The display string of the archival object's top container                                 | top_containers > long_display_string          |
+| ArchivalObjectContainer | The display string of the archival object's top container                                | top_containers > long_display_string          |
 
 >**Important:** Do **not** modify the `HostAppInfo.InstanceDataImport` table name (E.G. *HostAppInfo.InstanceDataImport[{**Table Name**}]*). The addon uses the table name to find the information. The data within the table, however, is designed to be customized.
 
@@ -86,33 +86,34 @@ InstanceDataImport establishes the mapping between an Aeon field and data from A
 Citation data can be imported when a specific instance of an object can't be imported or isn't supported yet. The citation data can be imported for `Resources`, `Accessions`, and `Digital Objects`. Each citation data type has its own mappings.
 
 #### Available ArchivesSpace Data- *Resources*
-| Data Mapping Name | Description                                                                               | ArchivesSpace API Property                    |
-|-------------------|-------------------------------------------------------------------------------------------|-----------------------------------------------|
-| Title             | The title of the resource                                                                 | resources > title                             |
-| FindingAidTitle   | The title of the resource that the archival object belongs to                             | resources > finding_aid_title                 |
-| DateExpression    | The date expression of the resource                                                       | resources > dates > date_expression           |
-| Creators          | The primary names, delimited by a `;`, of the creators associated with the resource  | agents > people > display_name > primary_name |
-| CreatedBy         | The user that created the record                                                          | resources > created_by                        |
-| EadId             | The EAD ID of the resource                                                                | resources > ead_id                            |
+| Data Mapping Name | Description                                                                         | ArchivesSpace API Property                    |
+| ----------------- | ----------------------------------------------------------------------------------- | --------------------------------------------- |
+| Title             | The title of the resource                                                           | resources > title                             |
+| FindingAidTitle   | The title of the resource that the archival object belongs to                       | resources > finding_aid_title                 |
+| DateExpression    | The date expression of the resource                                                 | resources > dates > date_expression           |
+| Creators          | The primary names, delimited by a `;`, of the creators associated with the resource | agents > people > display_name > primary_name |
+| CreatedBy         | The user that created the record                                                    | resources > created_by                        |
+| EadId             | The composite identifier of the resource                                            | resources > (id_0, id_1, id_2, id_3)          |
 
 #### Available ArchivesSpace Data- *Accessions*
-| Data Mapping Name | Description                                 | ArchivesSpace API Property           |
-|-------------------|---------------------------------------------|--------------------------------------|
-| Title             | The title of the accession                  | accessions > title                   |
-| DisplayString     | The display string of the accession record  | accessions > display_string          |
-| DateExpression    | The date expression of the accession record | accessions > dates > date_expression |
-| CreatedBy         | The user that created the record            | accessions > created_by              |
-| AccessionDate     | The date the accession was created          | accessions > accession_date          |
+| Data Mapping Name | Description                                 | ArchivesSpace API Property            |
+| ----------------- | ------------------------------------------- | ------------------------------------- |
+| Title             | The title of the accession                  | accessions > title                    |
+| DisplayString     | The display string of the accession record  | accessions > display_string           |
+| DateExpression    | The date expression of the accession record | accessions > dates > date_expression  |
+| CreatedBy         | The user that created the record            | accessions > created_by               |
+| AccessionDate     | The date the accession was created          | accessions > accession_date           |
+| EadId             | The composite identifier of the accession   | accessions > (id_0, id_1, id_2, id_3) |
 
 #### Available ArchivesSpace Data- *Digital Objects*
-| Data Mapping Name | Description                                                                            | ArchivesSpace API Property                    |
-|-------------------|----------------------------------------------------------------------------------------|-----------------------------------------------|
-| Title             | The title of the digital object                                                             | digital_objects > title                       |
-| DateExpression    | The date expression of the digital object                                              | digital_objects > dates > date_expression     |
-| CreatedBy         | The user that created the record                                                       | digital_objects > created_by                  |
-| FileUri           | The URI to the digital object's file                                              | digital_objects > file_uri                    |
+| Data Mapping Name | Description                                                                               | ArchivesSpace API Property                    |
+| ----------------- | ----------------------------------------------------------------------------------------- | --------------------------------------------- |
+| Title             | The title of the digital object                                                           | digital_objects > title                       |
+| DateExpression    | The date expression of the digital object                                                 | digital_objects > dates > date_expression     |
+| CreatedBy         | The user that created the record                                                          | digital_objects > created_by                  |
+| FileUri           | The URI to the digital object's file                                                      | digital_objects > file_uri                    |
 | Creators          | The primary names, delimited by a `;`, of the creators associated with the digital object | agents > people > display_name > primary_name |
-| DigitalObjectId   | The ID of the digital object                                                           | digital_objects > digital_object_id           |
+| DigitalObjectId   | The ID of the digital object                                                              | digital_objects > digital_object_id           |
 
 ### PageUri
 The PageUri mapping is the pattern that identifies the page type the addon is currently on. These are not likely to change from site to site, but can be adjusted if necessary.

--- a/Readme.md
+++ b/Readme.md
@@ -3,6 +3,8 @@
 ## Version
 - 1.3: Added support for importing citation data for Resources, Digital Objects, and Accessions. Added ability to import specific instance information for Archival Objects. The fields can be customized in the DataMapping.lua file.
 
+- 1.4: Added support for pulling identifiers from the composite ID string (`id_0` .. `id_N`), instead of relying on the `ead_id` field.
+
 ## Summary
 This addon is used to integrate the ArchivesSpace staff interface into the Aeon Client request form so that staff can search the records of their ArchivesSpace instance and import details into Aeon requests.
 


### PR DESCRIPTION
Added support for pulling resource / accession identifiers from `id_0`, `id_1`, `id_2`, and `id_3`, instead of pulling that information from the resource's `ead_id` field.

This increments the addon's version from 1.3.0 to 1.4.0.