### PR TITLE
Version 2.0 Release Candidate

### DIFF
--- a/Aeon-ArchivesSpace-Addon/Aeon-ArchivesSpace.lua
+++ b/Aeon-ArchivesSpace-Addon/Aeon-ArchivesSpace.lua
@@ -20,6 +20,7 @@ settings.ApiBaseURL = GetSetting("ArchivesSpaceBackendURL");
 settings.Username = GetSetting("AS_Username");
 settings.Password = GetSetting("AS_Password");
 settings.AutoSearchPriority = GetSetting("AutoSearchPriority");
+settings.AutoGroupResults = GetSetting("AutoGroupResults");
 
 local types = {};
 
@@ -39,6 +40,8 @@ luanet.load_assembly("System.Data");
 types["System.Data.DataTable"] = luanet.import_type("System.Data.DataTable");
 
 local currentRecordUri = "";
+
+local gridColumns = {};
 
 local archiveSpaceAddonScript = [[
     function buildObjectUrl(currentTreeId) {
@@ -198,6 +201,7 @@ function BuildItemsGrid()
     gridColumn.Visible = true;
     gridColumn.OptionsColumn.ReadOnly = true;
     gridColumn.Width = 50;
+    gridColumns["Title"] = gridColumn;
 
     gridColumn = gridView.Columns:Add();
     gridColumn.Caption = "SubTitle";
@@ -206,6 +210,7 @@ function BuildItemsGrid()
     gridColumn.Visible = true;
     gridColumn.OptionsColumn.ReadOnly = true;
     gridColumn.Width = 50;
+    gridColumns["SubTitle"] = gridColumn;
 
     gridColumn = gridView.Columns:Add();
     gridColumn.Caption = "Call Number";
@@ -214,6 +219,7 @@ function BuildItemsGrid()
     gridColumn.Visible = true;
     gridColumn.OptionsColumn.ReadOnly = true;
     gridColumn.Width = 50;
+    gridColumns["Call Number"] = gridColumn;
 
     gridColumn = gridView.Columns:Add();
     gridColumn.Caption = "Author";
@@ -222,6 +228,7 @@ function BuildItemsGrid()
     gridColumn.Visible = true;
     gridColumn.OptionsColumn.ReadOnly = true;
     gridColumn.Width = 50;
+    gridColumns["Author"] = gridColumn;
 
     gridColumn = gridView.Columns:Add();
     gridColumn.Caption = "Volume";
@@ -230,6 +237,7 @@ function BuildItemsGrid()
     gridColumn.Visible = true;
     gridColumn.OptionsColumn.ReadOnly = true;
     gridColumn.Width = 50;
+    gridColumns["Volume"] = gridColumn;
 
     gridColumn = gridView.Columns:Add();
     gridColumn.Caption = "Barcode";
@@ -238,6 +246,7 @@ function BuildItemsGrid()
     gridColumn.Visible = true;
     gridColumn.OptionsColumn.ReadOnly = true;
     gridColumn.Width = 50;
+    gridColumns["Barcode"] = gridColumn;
 
     gridColumn = gridView.Columns:Add();
     gridColumn.Caption = "Location";
@@ -246,6 +255,7 @@ function BuildItemsGrid()
     gridColumn.Visible = true;
     gridColumn.OptionsColumn.ReadOnly = true;
     gridColumn.Width = 50;
+    gridColumns["Location"] = gridColumn;
 
     catalogSearchForm.Grid.GridControl.DataSource = CreateItemsTable();
 
@@ -378,7 +388,6 @@ function ResetDataGrid()
 end
 
 function PopulateDataGrid()
-    local itemsDataTable = CreateItemsTable();
     LogDebug("Current Record URI: " .. currentRecordUri);
 
     if (string.match(currentRecordUri, HostAppInfo.PageUri["ArchivalObject"])) then
@@ -404,6 +413,8 @@ function PopulateDataGrid()
         availableData["ResourceTitle"] = ExtractProperty(collection, "title");
         availableData["EadId"] = ExtractProperty(collection,"ead_id");
         availableData["Creators"] = ExtractCreators(sessionId, collection);
+
+        local itemsDataTable = CreateItemsTable();
 
         catalogSearchForm.Grid.GridControl:BeginUpdate();
 
@@ -435,6 +446,11 @@ function PopulateDataGrid()
 
         catalogSearchForm.Grid.GridControl.DataSource = itemsDataTable;
         catalogSearchForm.Grid.GridControl:EndUpdate();
+
+        catalogSearchForm.Grid.GridControl.Enabled = true;
+        if settings.AutoGroupResults then
+            gridColumns["Volume"]:Group();
+        end
     end
 end
 

--- a/Aeon-ArchivesSpace-Addon/Aeon-ArchivesSpace.lua
+++ b/Aeon-ArchivesSpace-Addon/Aeon-ArchivesSpace.lua
@@ -38,7 +38,7 @@ types["System.Drawing.Size"] = luanet.import_type("System.Drawing.Size");
 luanet.load_assembly("System.Data");
 types["System.Data.DataTable"] = luanet.import_type("System.Data.DataTable");
 
-local currentResourceUri = "";
+local currentRecordUri = "";
 
 local archiveSpaceAddonScript = [[
     function buildObjectUrl(currentTreeId) {
@@ -61,7 +61,7 @@ local archiveSpaceAddonScript = [[
         var archivesSpaceAddonInitialized = true;
         var currentRepositoryPath = /\/repositories\/(\d+)/.exec($(".repo-container > .btn-group > a[href*='/repositories/']")[0].href)[0];
 
-        //Sets the currentResourceUri
+        //Sets the currentRecordUri
         if (currentRepositoryPath) {
             // There is an information tree
             if (window.AjaxTree) {
@@ -339,17 +339,17 @@ end
 
 function NodeChanged(currentRepositoryPath, selectedResourcePath)
     ResetDataGrid();
-    currentResourceUri = PathCombine(currentRepositoryPath, selectedResourcePath);
-    LogDebug('currentResourceUri = ' .. currentResourceUri);
+    currentRecordUri = PathCombine(currentRepositoryPath, selectedResourcePath);
+    LogDebug('currentRecordUri = ' .. currentRecordUri);
 
     SetImportButtonsDisabled();
 end
 
 function SetCitationImportButtonsEnabled()
     if(
-        string.match(currentResourceUri, HostAppInfo.PageUri["Resource"]) or
-        string.match(currentResourceUri, HostAppInfo.PageUri["Accession"]) or
-        string.match(currentResourceUri, HostAppInfo.PageUri["DigitalObject"])
+        string.match(currentRecordUri, HostAppInfo.PageUri["Resource"]) or
+        string.match(currentRecordUri, HostAppInfo.PageUri["Accession"]) or
+        string.match(currentRecordUri, HostAppInfo.PageUri["DigitalObject"])
     ) then
         LogDebug("Resource- Setting Import Citation to True");
         catalogSearchForm.ImportCitationButton.BarButton.Enabled = true;
@@ -379,12 +379,12 @@ end
 
 function PopulateDataGrid()
     local itemsDataTable = CreateItemsTable();
-    LogDebug("Current Resource URI: " .. currentResourceUri);
+    LogDebug("Current Record URI: " .. currentRecordUri);
 
-    if (string.match(currentResourceUri, HostAppInfo.PageUri["ArchivalObject"])) then
+    if (string.match(currentRecordUri, HostAppInfo.PageUri["ArchivalObject"])) then
 
         local sessionId = GetSessionId();
-        local archivalObject = GetArchivalObject(sessionId, currentResourceUri);
+        local archivalObject = GetArchivalObject(sessionId, currentRecordUri);
         local collectionUri = ExtractSubproperty(archivalObject, "resource", "ref");
         local collection = ArchivesSpaceGetRequest(sessionId, collectionUri);
 
@@ -475,7 +475,7 @@ function ImportCitation_Clicked()
     SetImportButtonsDisabled();
 
     local sessionId = GetSessionId();
-    local collection = ArchivesSpaceGetRequest(sessionId, currentResourceUri);
+    local collection = ArchivesSpaceGetRequest(sessionId, currentRecordUri);
     local jsonModelType = ExtractProperty(collection, "jsonmodel_type");
     LogDebug("Json Model Type: ".. jsonModelType);
     local availableData = {};

--- a/Aeon-ArchivesSpace-Addon/Aeon-ArchivesSpace.lua
+++ b/Aeon-ArchivesSpace-Addon/Aeon-ArchivesSpace.lua
@@ -420,11 +420,12 @@ function PopulateDataGrid()
 
         for _, archivalObjectInstance in ipairs(instances) do
             
-            local topContainer = GetTopContainerFromAPI(sessionId, archivalObjectInstance)
+            local topContainer = GetTopContainerFromAPI(sessionId, archivalObjectInstance);
+            local digitalObject = GetDigitalObjectFromAPI(sessionId, archivalObjectInstance);
 
-            availableData["ArchivalObjectContainer"] = ExtractArchivalObjectContainer(archivalObjectInstance, topContainer);
-            availableData["ArchivalObjectContainerBarcode"] = ExtractArchivalObjectContainerBarcode(topContainer);
-            
+            availableData["ArchivalObjectInstance"] = ExtractArchivalObjectInstanceTitle(archivalObjectInstance, topContainer, digitalObject);
+            availableData["ArchivalObjectInstanceBarcode"] = ExtractArchivalObjectInstanceBarcode(topContainer, digitalObject);
+
             topContainerHasContainerLocations = (
                 topContainer and
                 topContainer.container_locations and
@@ -574,7 +575,17 @@ function GetTopContainerFromAPI(sessionId, archivalObjectInstance)
     return nil
 end
 
-function ExtractArchivalObjectContainer(archivalObjectInstance, topContainer)
+function GetDigitalObjectFromAPI(sessionId, archivalObjectInstance)
+    if (archivalObjectInstance.digital_object ~= nil and archivalObjectInstance.digital_object ~= JsonParser.NIL) then
+        local digitalObjectUri = archivalObjectInstance.digital_object.ref;
+        local digitalObject = ArchivesSpaceGetRequest(sessionId, digitalObjectUri);
+        return digitalObject
+    end
+
+    return nil
+end
+
+function ExtractArchivalObjectInstanceTitle(archivalObjectInstance, topContainer, digitalObject)
     local container = "";
 
     if (archivalObjectInstance.container ~= nil and archivalObjectInstance.container ~= JsonParser.NIL) then
@@ -587,16 +598,20 @@ function ExtractArchivalObjectContainer(archivalObjectInstance, topContainer)
         end
     elseif (topContainer) then
         container = topContainer.long_display_string;
+    elseif (digitalObject) then
+        container = digitalObject.title;
     end
 
     return container;
 end
 
-function ExtractArchivalObjectContainerBarcode(topContainer)
+function ExtractArchivalObjectInstanceBarcode(topContainer, digitalObject)
     local barcode = "";
 
     if topContainer and topContainer.barcode then
         barcode = topContainer.barcode;
+    elseif digitalObject and digitalObject.digital_object_id then
+        barcode = digitalObject.digital_object_id;
     end
 
     return barcode;

--- a/Aeon-ArchivesSpace-Addon/Config.xml
+++ b/Aeon-ArchivesSpace-Addon/Config.xml
@@ -2,7 +2,7 @@
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>ArchivesSpace Interface</Name>
   <Author>Atlas Systems, Inc.</Author>
-  <Version>1.3.0</Version>
+  <Version>2.0.0</Version>
   <Active>True</Active>
   <Type>Addon</Type>
   <Description>This addon performs searches in ArchivesSpace using the staff interface. This addon supports ArchivesSpace versions v2.0.0 and later.</Description>

--- a/Aeon-ArchivesSpace-Addon/Config.xml
+++ b/Aeon-ArchivesSpace-Addon/Config.xml
@@ -29,7 +29,7 @@
 			<Description>A comma-separated list of searches to be performed in order.</Description>
 		</Setting>
     <Setting name="AutoGroupResults" value="false" type="boolean">
-			<Description>Specifies whether the results grid should be grouped by top container display string.</Description>
+			<Description>Specifies whether the results grid should be grouped automatically. The table will be grouped by the "Volume" column, which refers to either the instance's top container display string or digital object title.</Description>
 		</Setting>
   </Settings>
   <Files>

--- a/Aeon-ArchivesSpace-Addon/Config.xml
+++ b/Aeon-ArchivesSpace-Addon/Config.xml
@@ -28,6 +28,9 @@
     <Setting name="AutoSearchPriority" value="Title, Author, CallNumber" type="string">
 			<Description>A comma-separated list of searches to be performed in order.</Description>
 		</Setting>
+    <Setting name="AutoGroupResults" value="false" type="boolean">
+			<Description>Specifies whether the results grid should be grouped by top container display string.</Description>
+		</Setting>
   </Settings>
   <Files>
     <File>Aeon-ArchivesSpace.lua</File>

--- a/Aeon-ArchivesSpace-Addon/DataMapping.lua
+++ b/Aeon-ArchivesSpace-Addon/DataMapping.lua
@@ -62,12 +62,12 @@ HostAppInfo.InstanceDataImport["Author"] =
 
 HostAppInfo.InstanceDataImport["Volume"] =
 {
-  AeonField = "ItemVolume", AspaceData = "ArchivalObjectContainer", FieldLength = 255, ItemGridColumn = "Volume"
+  AeonField = "ItemVolume", AspaceData = "ArchivalObjectInstance", FieldLength = 255, ItemGridColumn = "Volume"
 }
 
 HostAppInfo.InstanceDataImport["Barcode"] =
 {
-  AeonField = "ItemNumber", AspaceData = "ArchivalObjectContainerBarcode", FieldLength = 50, ItemGridColumn = "Barcode"
+  AeonField = "ItemNumber", AspaceData = "ArchivalObjectInstanceBarcode", FieldLength = 50, ItemGridColumn = "Barcode"
 }
 
 HostAppInfo.InstanceDataImport["Location"] =

--- a/Aeon-ArchivesSpace-Addon/DataMapping.lua
+++ b/Aeon-ArchivesSpace-Addon/DataMapping.lua
@@ -70,6 +70,11 @@ HostAppInfo.InstanceDataImport["Barcode"] =
   AeonField = "ItemNumber", AspaceData = "ArchivalObjectContainerBarcode", FieldLength = 50, ItemGridColumn = "Barcode"
 }
 
+HostAppInfo.InstanceDataImport["Location"] =
+{
+  AeonField = "Location", AspaceData = "ArchivalObjectContainerLocation", FieldLength = 255, ItemGridColumn = "Location"
+}
+
 -- Resource Citation Import Mapping
 HostAppInfo.CitationDataImport = {}
 

--- a/Readme.md
+++ b/Readme.md
@@ -7,9 +7,11 @@
       to an instance's Top container.
     - Added support for pulling instance information from the Resource level if
       the current Archival Object does not have any instances.
-    - Added the `GroupResultsByVolume` setting, allowing users to opt-in to
-      automatically grouping the results grid by the top container display
-      string.
+    - Added the `AutoGroupResults` setting, allowing users to opt-in to
+      automatically grouping the results grid by the "Volume" column, which
+      refers to either the instance's top container display string or the
+      instance's digital object title, depending on the instance type.
+    - Added support for pulling in information from digital object instances.
 - 1.3:
     - Added support for importing citation data for Resources, Digital Objects, and Accessions.
     - Added ability to import specific instance information for Archival Objects.
@@ -57,6 +59,12 @@ A comma-separated list of searches to be performed in order.
 
 *Available Search Types:* Title, Author, CallNumber
 
+### AutoGroupResults
+
+Specifies whether the results grid should be grouped automatically. The table
+will be grouped by the "Volume" column, which refers to either the instance's
+top container display string or digital object title.
+
 ## Data Mapping
 The `DataMapping.lua` file contains mappings that can be modified in order to fine-tune the addon to a particular instanance of ArchivesSpace. Examples of mapping includes adjusting the ArchivesSpace search types to specific Aeon fields, the mapping between Aeon fields and the different ArchivesSpace object types, and the patterns used to identify the types of pages the user is on.
 
@@ -84,13 +92,15 @@ InstanceDataImport establishes the mapping between an Aeon field and data from A
 
 #### Available ArchivesSpace Data- *Archival Object*
 
-| Data Mapping Name       | Description                                                                               | ArchivesSpace API Property                    |
-|-------------------------|-------------------------------------------------------------------------------------------|-----------------------------------------------|
-| ArchivalObjectTitle     | The title of the archival object                                                          | archival_objects > title                      |
-| ResourceTitle           | The title of the resource that the archival object belongs to                             | resources > title                             |
-| EadId                   | The resource's EAD ID                                                                     | resources > ead_id                            |
-| Creators                | The primary names of the creators associated with the archival object delimited by a `;` | agents > people > display_name > primary_name |
-| ArchivalObjectContainer | The display string of the archival object's top container                                 | top_containers > long_display_string          |
+| Data Mapping Name               | Description                                                                               | ArchivesSpace API Property                                          |
+|---------------------------------|-------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| ArchivalObjectTitle             | The title of the archival object                                                          | `archival_objects > title`                                          |
+| ResourceTitle                   | The title of the resource that the archival object belongs to                             | `resources > title`                                                 |
+| EadId                           | The resource's EAD ID                                                                     | `resources > ead_id`                                                |
+| Creators                        | The primary names of the creators associated with the archival object delimited by a `;`  | `agents > people > display_name > primary_name`                     |
+| ArchivalObjectInstance          | The display string of the archival object's instance's top container or digital object.   | `top_container > long_display_string` (OR) `digital_object > title` |
+| ArchivalObjectInstanceBarcode   | The barcode or ID of the archival object's instance's top container or digital object.    | `top_container > barcode` (OR) `digital_object > digital_object_id` |
+| ArchivalObjectContainerLocation | The title of the container's location if the instance is a top container instance.        | `location > title`                                                  |
 
 >**Important:** Do **not** modify the `HostAppInfo.InstanceDataImport` table name (E.G. *HostAppInfo.InstanceDataImport[{**Table Name**}]*). The addon uses the table name to find the information. The data within the table, however, is designed to be customized.
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,16 @@
 # Aeon ArchivesSpace Client Addon
 
 ## Version
-- 1.3: Added support for importing citation data for Resources, Digital Objects, and Accessions. Added ability to import specific instance information for Archival Objects. The fields can be customized in the DataMapping.lua file.
+- 2.0:
+    - Added support for importing the barcode from an instance's Top Container.
+    - Added support for importing the titles from each Location that is linked
+      to an instance's Top container.
+    - Added support for pulling instance information from the Resource level if
+      the current Archival Object does not have any instances.
+- 1.3:
+    - Added support for importing citation data for Resources, Digital Objects, and Accessions.
+    - Added ability to import specific instance information for Archival Objects.
+    - The fields can be customized in the DataMapping.lua file.
 
 ## Summary
 This addon is used to integrate the ArchivesSpace staff interface into the Aeon Client request form so that staff can search the records of their ArchivesSpace instance and import details into Aeon requests.

--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,9 @@
       to an instance's Top container.
     - Added support for pulling instance information from the Resource level if
       the current Archival Object does not have any instances.
+    - Added the `GroupResultsByVolume` setting, allowing users to opt-in to
+      automatically grouping the results grid by the top container display
+      string.
 - 1.3:
     - Added support for importing citation data for Resources, Digital Objects, and Accessions.
     - Added ability to import specific instance information for Archival Objects.


### PR DESCRIPTION
- Added support for importing the barcode from an instance's Top Container.
- Added support for importing the titles from each Location that is linked to an instance's Top container.
- Added support for pulling instance information from the Resource level if the current Archival Object does not have any instances.
- Added the `AutoGroupResults` setting, allowing users to opt-in to automatically grouping the results grid by the "Volume" column, which refers to either the instance's top container display string or the instance's digital object title, depending on the instance type.
- Added support for pulling in information from digital object instances.